### PR TITLE
refactor: Move highlightCrossingProperty to MembraneTransportModel

### DIFF
--- a/js/common/model/MembraneTransportModel.ts
+++ b/js/common/model/MembraneTransportModel.ts
@@ -137,6 +137,8 @@ export default class MembraneTransportModel extends PhetioObject {
   // Updated lazily in step(), by checking the state of each ligand
   public readonly isUserDraggingLigandProperty = new BooleanProperty( false );
 
+  public readonly highlightCrossingProperty: Property<boolean>;
+
   public constructor(
     public readonly featureSet: MembraneTransportFeatureSet,
     providedOptions: MembraneTransportModelOptions ) {
@@ -194,6 +196,12 @@ export default class MembraneTransportModel extends PhetioObject {
       phetioFeatured: true
     } );
     this.resetEmitter.addListener( () => this.areLigandsAddedProperty.reset() );
+
+    this.highlightCrossingProperty = new BooleanProperty( true, {
+      tandem: options.tandem.createTandem( 'highlightCrossingProperty' )
+      // phetioFeatured: true // Not specified for model properties unless they are part of preferences.
+    } );
+    this.resetEmitter.addListener( () => this.highlightCrossingProperty.reset() );
 
     getFeatureSetSoluteTypes( this.featureSet ).forEach( soluteType => {
       this.outsideSoluteCountProperties[ soluteType ] = new NumberProperty( 0 );

--- a/js/common/view/MembraneTransportScreenView.ts
+++ b/js/common/view/MembraneTransportScreenView.ts
@@ -16,6 +16,7 @@ import ModelViewTransform2 from '../../../../phetcommon/js/view/ModelViewTransfo
 import EraserButton from '../../../../scenery-phet/js/buttons/EraserButton.js';
 import ResetAllButton from '../../../../scenery-phet/js/buttons/ResetAllButton.js';
 import TimeControlNode from '../../../../scenery-phet/js/TimeControlNode.js';
+import Checkbox from '../../../../scenery-phet/js/Checkbox.js';
 import ParallelDOM from '../../../../scenery/js/accessibility/pdom/ParallelDOM.js';
 import VBox from '../../../../scenery/js/layout/nodes/VBox.js';
 import KeyboardListener from '../../../../scenery/js/listeners/KeyboardListener.js';
@@ -123,6 +124,13 @@ export default class MembraneTransportScreenView extends ScreenView {
     } );
 
     this.addChild( timeControlNode );
+
+    const highlightCrossingCheckbox = new Checkbox( this.model.highlightCrossingProperty, MembraneTransportFluent.highlightCrossingStringProperty, {
+      tandem: options.tandem.createTandem( 'highlightCrossingCheckbox' ),
+      left: timeControlNode.left,
+      top: timeControlNode.bottom + MembraneTransportConstants.SCREEN_VIEW_Y_MARGIN
+    } );
+    this.addChild( highlightCrossingCheckbox );
 
     // A parent Node for the controls related to selecting solutes, adding solutes, and removing solutes.
     const soluteControlsNode = new Node( {
@@ -259,6 +267,7 @@ export default class MembraneTransportScreenView extends ScreenView {
 
     this.pdomControlAreaNode.pdomOrder = [
       timeControlNode,
+      highlightCrossingCheckbox,
       resetAllButton
     ];
 

--- a/js/common/view/ObservationWindowCanvasNode.ts
+++ b/js/common/view/ObservationWindowCanvasNode.ts
@@ -136,10 +136,11 @@ export default class ObservationWindowCanvasNode extends CanvasNode {
       const width = this.modelViewTransform.modelToViewDeltaX( solute.dimension.width );
       const height = this.modelViewTransform.modelToViewDeltaY( solute.dimension.height );
 
-      if ( solute.timeSinceCrossedMembrane > 0 && solute.timeSinceCrossedMembrane < 0.2 ) {
+      if ( this.model.highlightCrossingProperty.value ) {
+        if ( solute.timeSinceCrossedMembrane > 0 && solute.timeSinceCrossedMembrane < 0.2 ) {
 
-        // draw a highlight
-        context.fillStyle = 'white';
+          // draw a highlight
+          context.fillStyle = 'white';
         context.globalAlpha = 0.5;
         context.beginPath();
         context.arc( x, y, width / 2 * 1.2, 0, Math.PI * 2 );
@@ -147,6 +148,7 @@ export default class ObservationWindowCanvasNode extends CanvasNode {
         context.globalAlpha = 1.0;
         context.fillStyle = 'black';
 
+        }
       }
 
       // Potassium rotates 20 degrees when it is in the sodium potassium pump, and the pump is open to the outside.

--- a/membrane-transport-strings_en.yaml
+++ b/membrane-transport-strings_en.yaml
@@ -38,6 +38,7 @@ animateLipidsDescription:                               Whether the phospholipid
 glucoseDrain:                                           Glucose Drain
 glucoseDrainDescription:                                Simulate phosphorylation of glucose in the cell after transport. Simulation assumes a high concentration of glucose inside the cell.
 soluteConcentrations:                                   Solute Concentrations
+highlightCrossing: Highlight Crossing
 
 preferencesDialog.audio.sounds.stereoSounds:            Stereo Sounds
 preferencesDialog.audio.sounds.stereoSoundsDescription: Emphasize solute transport direction by mapping sound to right (outside to inside) and left (inside to outside) channels.


### PR DESCRIPTION
Moves the `highlightCrossingProperty` from `MembraneTransportPreferences` to `MembraneTransportModel` as per your feedback.

The property is now instantiated in the `MembraneTransportModel` constructor and reset with the model. `MembraneTransportScreenView` and `ObservationWindowCanvasNode` have been updated to reference the property from the model instance.

This commit amends the previous work for the 'Highlight Crossing' checkbox feature.

Addresses https://github.com/phetsims/membrane-transport/issues/68